### PR TITLE
Support for current Spike

### DIFF
--- a/hammer.cpp
+++ b/hammer.cpp
@@ -41,13 +41,16 @@ Hammer::Hammer(const char *isa, const char *privilege_levels, const char *vector
   std::pair<reg_t, reg_t> initrd_bounds{0, 0};
   const char *bootargs = nullptr;
   bool real_time_clint = false;
+  bool misaligned = false;
+
+  reg_t trigger_count = 4;
 
   reg_t num_pmpregions = 16;
 
   endianness_t endinaness = endianness_little;
 
-  cfg_t cfg = cfg_t(initrd_bounds, bootargs, isa, privilege_levels, vector_arch, endinaness, num_pmpregions, memory_layout,
-                    hart_ids, real_time_clint);
+  cfg_t cfg = cfg_t(initrd_bounds, bootargs, isa, privilege_levels, vector_arch, misaligned, endinaness, num_pmpregions, memory_layout,
+                    hart_ids, real_time_clint, trigger_count);
 
   if (start_pc.has_value()) {
     cfg.start_pc = start_pc.value();

--- a/hammer.cpp
+++ b/hammer.cpp
@@ -16,7 +16,7 @@ static std::vector<std::pair<reg_t, mem_t *>> make_mems(const std::vector<mem_cf
   std::vector<std::pair<reg_t, mem_t *>> mems;
   mems.reserve(layout.size());
   for (const auto &cfg : layout) {
-    mems.push_back(std::make_pair(cfg.base, new mem_t(cfg.size)));
+    mems.push_back(std::make_pair(cfg.get_base(), new mem_t(cfg.get_size())));
   }
   return mems;
 }

--- a/hammer.cpp
+++ b/hammer.cpp
@@ -22,7 +22,7 @@ static std::vector<std::pair<reg_t, mem_t *>> make_mems(const std::vector<mem_cf
 }
 
 Hammer::Hammer(const char *isa, const char *privilege_levels, const char *vector_arch,
-               std::vector<int> hart_ids, std::vector<mem_cfg_t> memory_layout,
+               std::vector<size_t> hart_ids, std::vector<mem_cfg_t> memory_layout,
                const std::string target_binary, const std::optional<uint64_t> start_pc) {
   // Expose these only if needed
   std::vector<std::pair<reg_t, abstract_device_t *>> plugin_devices;

--- a/hammer.h
+++ b/hammer.h
@@ -13,7 +13,7 @@
 class Hammer {
  public:
   Hammer(const char *isa, const char *privilege_levels, const char *vector_arch,
-         std::vector<int> hart_ids, std::vector<mem_cfg_t> memory_layout,
+         std::vector<size_t> hart_ids, std::vector<mem_cfg_t> memory_layout,
          const std::string target_binary, const std::optional<uint64_t> start_pc = std::nullopt);
   ~Hammer();
 

--- a/hammer_pybind.cpp
+++ b/hammer_pybind.cpp
@@ -15,7 +15,7 @@ PYBIND11_MODULE(hammer, m) {
   pybind11::class_<mem_t>(m, "mem_t").def(pybind11::init<reg_t>());
 
   pybind11::class_<Hammer>(m, "Hammer")
-      .def(pybind11::init<const char *, const char *, const char *, std::vector<int>,
+      .def(pybind11::init<const char *, const char *, const char *, std::vector<size_t>,
                           std::vector<mem_cfg_t>, const std::string,
                           const std::optional<uint64_t>>())
       .def("hello_world", &Hammer::hello_world)

--- a/tests/test000.cpp
+++ b/tests/test000.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
   // This is what Spike sets it to
   memory_layout.push_back(mem_cfg_t(reg_t(DRAM_BASE), reg_t(2048) << 20));
 
-  std::vector<int> hart_ids{0};
+  std::vector<size_t> hart_ids{0};
 
   Hammer hammer = Hammer("RV64GCV", "MSU", "vlen:512,elen:32", hart_ids, memory_layout,
                          target_binary, std::nullopt);

--- a/tests/test001.cpp
+++ b/tests/test001.cpp
@@ -12,7 +12,7 @@ int main(int argc, char *argv[]) {
   // This is what Spike sets it to
   memory_layout.push_back(mem_cfg_t(reg_t(DRAM_BASE), reg_t(2048) << 20));
 
-  std::vector<int> hart_ids{0};
+  std::vector<size_t> hart_ids{0};
 
   Hammer hammer = Hammer("RV64GCV", "MSU", "vlen:512,elen:64", hart_ids, memory_layout,
                          target_binary, std::nullopt);

--- a/tests/test002.cpp
+++ b/tests/test002.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[]) {
   // This is what Spike sets it to
   memory_layout.push_back(mem_cfg_t(reg_t(DRAM_BASE), reg_t(2048) << 20));
 
-  std::vector<int> hart_ids{0};
+  std::vector<size_t> hart_ids{0};
 
   Hammer hammer = Hammer("RV64GCV", "MSU", "vlen:512,elen:64", hart_ids, memory_layout,
                          target_binary, std::nullopt);

--- a/tests/test003.cpp
+++ b/tests/test003.cpp
@@ -15,7 +15,7 @@ int main(int argc, char *argv[]) {
   std::vector<std::string> htif_args;
   htif_args.push_back(target_binary);
 
-  std::vector<int> hart_ids{0};
+  std::vector<size_t> hart_ids{0};
 
   Hammer hammer = Hammer("RV64GCV", "MSU", "vlen:512,elen:64", hart_ids, memory_layout,
                          target_binary, std::nullopt);


### PR DESCRIPTION
Tested with 6d55547209f55737df8b3d28e0f0834a38368b64.
All tests pass