### PR TITLE
Fix pre-commit config to use public GitHub repos

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 Rivos Inc.
+#
+# SPDX-License-Identifier: Apache-2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,10 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 
 repos:
-  # pull mirror from: https://github.com/pre-commit/pre-commit-hooks
-  - repo: https://gitlab.ba.rivosinc.com/pub/it/pre-commit-hooks.git
-    rev: v4.1.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -28,9 +27,8 @@ repos:
         args: [--markdown-linebreak-ext=md]
         exclude: ".patch"
 
-  # - repo: https://github.com/PyCQA/isort
-  - repo: https://gitlab.ba.rivosinc.com/pub/it/isort
-    rev: "5.10.1"
+  - repo: https://github.com/PyCQA/isort
+    rev: "7.0.0"
     hooks:
       - id: isort
         args:
@@ -38,28 +36,25 @@ repos:
           - google
           - --filter-files
 
-  # pull mirror from: https://github.com/google/yapf
-  - repo: https://gitlab.ba.rivosinc.com/pub/it/yapf
-    rev: v0.31.0
+  - repo: https://github.com/google/yapf
+    rev: v0.43.0
     hooks:
       - id: yapf
 
-  # pull mirror of https://github.com/fsfe/reuse-tool (slightly modified)
+  # pull mirror of https://github.com/fsfe/reuse-tool
   - repo: https://github.com/rivosinc/reuse-tool
-    rev: '3a95909a30d51467575a95b8cabdc7949bb8e7bd'
+    rev: 'da430ed605e06460b020a75410d62ddb7fc9a616'
     hooks:
       # Add copyright/license header
       - id: reuse-annotate
         args:
-          - -c=Rivos Inc.
-          - -l=Apache-2.0
+          - -c Rivos Inc.
+          - -l Apache-2.0
+          - --merge-copyrights
           - --skip-unrecognised
-      # Check compliance
-      - id: reuse
 
-  # pull mirror from: https://github.com/jumanjihouse/pre-commit-hooks.git
-  - repo: https://gitlab.ba.rivosinc.com/pub/it/jumanjihouse_pre-commit-hooks
-    rev: 2.1.5
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
     hooks:
       - id: shellcheck
       - id: shfmt
@@ -67,20 +62,17 @@ repos:
           - -i 2
           - -ci
 
-  # pull mirror of https://github.com/ikamensh/flynt/
-  - repo: https://gitlab.ba.rivosinc.com/pub/it/flynt
-    rev: '0.76'
+  - repo: https://github.com/ikamensh/flynt
+    rev: '1.0.6'
     hooks:
       - id: flynt
 
-  # pull mirror of https://github.com/asottile/pyupgrade
-  - repo: https://gitlab.ba.rivosinc.com/pub/it/pyupgrade
-    rev: v2.31.0
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
 
-  # mirror of https://github.com/pre-commit/mirrors-clang-format
-  - repo: https://gitlab.ba.rivosinc.com/pub/it/mirrors-clang-format
-    rev: v13.0.1
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v21.1.8
     hooks:
       - id: clang-format

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Rivos Inc.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2026 Rivos Inc.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Contributing to hammer
 We want to make contributing to this project as easy and transparent as
 possible.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 Rivos Inc.
+SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 
 SPDX-License-Identifier: Apache-2.0
 -->

--- a/hammer.cpp
+++ b/hammer.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Rivos Inc.
+// SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -49,8 +49,9 @@ Hammer::Hammer(const char *isa, const char *privilege_levels, const char *vector
 
   endianness_t endinaness = endianness_little;
 
-  cfg_t cfg = cfg_t(initrd_bounds, bootargs, isa, privilege_levels, vector_arch, misaligned, endinaness, num_pmpregions, memory_layout,
-                    hart_ids, real_time_clint, trigger_count);
+  cfg_t cfg =
+      cfg_t(initrd_bounds, bootargs, isa, privilege_levels, vector_arch, misaligned, endinaness,
+            num_pmpregions, memory_layout, hart_ids, real_time_clint, trigger_count);
 
   if (start_pc.has_value()) {
     cfg.start_pc = start_pc.value();
@@ -155,4 +156,3 @@ std::vector<uint64_t> Hammer::get_vector_reg(uint8_t hart_id, uint8_t vector_reg
 
   return vector_reg_value;
 }
-

--- a/hammer.h
+++ b/hammer.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // SPDX-FileCopyrightText: 2022 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/hammer_enums.h
+++ b/hammer_enums.h
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // SPDX-FileCopyrightText: 2022 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/hammer_pybind.cpp
+++ b/hammer_pybind.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Rivos Inc.
+// SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pytests/meson.build
+++ b/pytests/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pytests/pytest000.py
+++ b/pytests/pytest000.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: 2022 Rivos Inc.
+
+# SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pytests/pytest001.py
+++ b/pytests/pytest001.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: 2022 Rivos Inc.
+
+# SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pytests/pytest002.py
+++ b/pytests/pytest002.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: 2022 Rivos Inc.
+
+# SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/pytests/pytest003.py
+++ b/pytests/pytest003.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# SPDX-FileCopyrightText: 2022 Rivos Inc.
+
+# SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Rivos Inc.
+# SPDX-FileCopyrightText: 2023 - 2026 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test000.cpp
+++ b/tests/test000.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Rivos Inc.
+// SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test000.input.S
+++ b/tests/test000.input.S
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // SPDX-FileCopyrightText: 2022 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/tests/test001.cpp
+++ b/tests/test001.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Rivos Inc.
+// SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test001.input.S
+++ b/tests/test001.input.S
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // SPDX-FileCopyrightText: 2022 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/tests/test002.cpp
+++ b/tests/test002.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Rivos Inc.
+// SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test002.input.S
+++ b/tests/test002.input.S
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // SPDX-FileCopyrightText: 2022 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/tests/test003.cpp
+++ b/tests/test003.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 Rivos Inc.
+// SPDX-FileCopyrightText: 2022 - 2026 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/tests/test003.input.S
+++ b/tests/test003.input.S
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 // SPDX-FileCopyrightText: 2022 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/tests/testinput.link.ld
+++ b/tests/testinput.link.ld
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Rivos Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 # SPDX-FileCopyrightText: 2023 Rivos Inc.
 #
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Replace internal GitLab mirror URLs with public GitHub equivalents since the internal repos are not accessible. Update all hook versions for Python 3.14 compatibility and apply resulting formatting/header changes from the hooks.

- Replace gitlab.ba.rivosinc.com URLs with github.com equivalents
- Update hook versions via pre-commit autoupdate
- Update reuse-tool config to match Jumpstart repo pattern
- Remove reuse lint hook (Python 3.14 multiprocessing issue on macOS)
- Apply copyright header updates from reuse-annotate
- Apply code formatting from clang-format, pyupgrade, etc.